### PR TITLE
build: downgrade @types/node version to v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@cypress/schematic": "^3.0.0",
     "@cypress/webpack-preprocessor": "^6.0.4",
     "@types/jasmine": "^6.0.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "commit-and-tag-version": "^12.7.1",


### PR DESCRIPTION
Downgrade @types/node from version 25.6.0 to 20.10.0 as angular@17 is only compatible with node@20.